### PR TITLE
Set --show_result=MAX_INT

### DIFF
--- a/src/compilationDatabase.ts
+++ b/src/compilationDatabase.ts
@@ -83,6 +83,7 @@ export function createBazelBuildAspectCommand(
         "--override_repository=bazel_vscode_compdb=" + repositoryPath,
         "--aspects=@bazel_vscode_compdb//:aspects.bzl%compilation_database_aspect",
         "--color=no",
+        "--show_result=2147483647", // MAX_INT
         "--noshow_progress",
         "--noshow_loading_progress",
         "--output_groups=compdb_files,header_files",


### PR DESCRIPTION
When compilation database has multiple targets...

```json
    "bsv.cc.compdb.targets": [
        "//absl/time:time",
        "//absl/random:random",
    ],
```

...compilation database is empty.  Since we are parsing the progress events for those files, it means no json files are found.  This is because the bazel flag `--show_result` defaults to `1`.

```
--show_result
default: integer 1
    Show the results of the build.  For each target, state whether or not it 
    was brought up-to-date, and if so, a list of output files that were built.  
    The printed files are convenient strings for copy+pasting to the shell, to 
    execute them.
    This option requires an integer argument, which is the threshold number of 
    targets above which result information is not printed. Thus zero causes 
    suppression of the message and MAX_INT causes printing of the result to 
    occur always.  The default is one.

affects_outputs
```

This PR sets it to MAX_INT.

Fixes #11 