### PR TITLE
Do not add duplicate json files to compilation db

### DIFF
--- a/compdb/postprocess.py
+++ b/compdb/postprocess.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     print("Preparing compilation database...")
 
     db_entries = []
-    for db in compile_command_json_db_files:
+    for db in set(compile_command_json_db_files):
             with open(db, 'r') as f:
                 db_entries.extend(json.load(f))
 


### PR DESCRIPTION
The list of temporary compile command json files generated on build events can have many duplicates. This PR deduplicates that list before building up the compilation db.

This can lead to massive reductions in size (100x in my case). The raw list was something like 500k files, with only 3600 of them being unique. The resulting `compile_commands.json` is substantially smaller -- with duplicates, I've seen it as large as 11GB for my configuration; with this change, it is 166MB

`clangd` doesn't cope well with a large and heavily duplicated json file, and tends to run out of memory.